### PR TITLE
Update airflow version to 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM puckel/docker-airflow:1.9.0-4
+FROM puckel/docker-airflow:1.10.0-2
 
 USER root
 


### PR DESCRIPTION
- Uses `puckel/docker-airflow:1.10.0-2` image with airflow version to 1.10.0