### PR TITLE
Update airflow to 1.10.2 and reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,36 +2,34 @@ FROM puckel/docker-airflow:1.10.2
 
 USER root
 
-RUN apt-get update && apt-get install -y \
-    gnupg2 \
-    curl apt-transport-https debconf-utils \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/debian/8/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-# Install SQL Server drivers and client tools.
-
 ENV ACCEPT_EULA=Y
 
-RUN apt-get update && \
-    apt-get upgrade -y libc6
-
-RUN apt-get install -y msodbcsql mssql-tools unixodbc-dev && \
-    apt-get install -y --reinstall --upgrade g++ gcc
-
-# Install python dependencies.
-RUN /bin/bash -c "source ~/.bashrc" && \
-    pip install --upgrade six && \
-    pip install pyodbc psycopg2-binary
-
-RUN echo "deb http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list
-RUN apt-get update && \
-    apt-get install libssl1.0.0
+RUN apt-get update && apt-get install -y \
+    gnupg2 \
+    curl apt-transport-https debconf-utils && \
+    echo "deb http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/debian/8/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    apt-get upgrade -y libc6 && \
+    apt-get install -y \
+        msodbcsql \
+        mssql-tools \
+        unixodbc-dev \
+        libssl1.0.0  && \
+    apt-get install -y --reinstall --upgrade \
+        g++ \
+        gcc && \
+    /bin/bash -c "source ~/.bashrc" && \
+    pip install --upgrade \
+        six \
+        pyodbc \
+        psycopg2-binary && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
 
 USER airflow
 
 RUN pip install fabric3 flask_bcrypt slackclient boto3 --user
 
-ENV PATH="$PATH:/opt/mssql-tools/bin"
-ENV PATH="$PATH:/usr/local/airflow/.local/bin"
+ENV PATH="$PATH:/opt/mssql-tools/bin:/usr/local/airflow/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM puckel/docker-airflow:1.10.0-2
+FROM puckel/docker-airflow:1.10.2
 
 USER root
 


### PR DESCRIPTION
## Changes

* Update airflow to 1.10.2
* Follow Dockerfile best practices to reduce total image size

## Details

1. Updated airflow version to `1.10.2` which has plugins support for `RBAC` enabled airflow setup.
2. Reorganized `Dockerfile` statements and reduced the total image size from `1.19 GB` -> `894 MB` :champagne:

**Note:** Need to get this merged and push new image to `laudio/airflow-mssql:1.0.9`