### PR TITLE
Add hvac package as a dependency for vault integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ RUN apt-get update && apt-get install -y \
 
 USER airflow
 
-RUN pip install fabric3 flask_bcrypt slackclient boto3 xlrd --user
+RUN pip install fabric3 flask_bcrypt slackclient boto3 xlrd hvac==0.6.4 --user
 
 ENV PATH="$PATH:/opt/mssql-tools/bin:/usr/local/airflow/.local/bin"


### PR DESCRIPTION
Add `hvac==0.6.4` as a dependency for vault integration.

Will tag and publish `1.0.11` once merged. 